### PR TITLE
Drop numpy upper bound, run CI weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    # Sundays 00:00 UTC. No lockfile is committed, so uv resolves fresh each
+    # run and this catches upstream releases that break us before users hit them.
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
   check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "Python library for water segmentation in high to moderate resolution remotely sensed imagery"
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=2.0,<2.4", # upper bound needed until numba supports numpy 2.4+
+    "numpy>=2.0",
     "omnicloudmask>=1.7.1",
     "opencv-python>=4.9.0.80",
     "geopandas>=1.0",


### PR DESCRIPTION
## Drop the numpy upper bound

`numpy>=2.0,<2.4` → `numpy>=2.0`.

The cap existed to keep numba installable, but **numba is not a runtime dependency** — it only enters through the dev group, via `s2mosaic` → `numbagg` → `numba`. The bound therefore constrained every downstream install to protect a package users never receive. numba also declares its own ceiling (`numpy<2.6` as of 0.67), so the resolver handles the dev-side constraint without help.

A fresh resolve after the change:

| | before | after |
|---|---|---|
| numpy (3.12+) | 2.3.5 | 2.5.2 |
| numpy (3.11) | 2.3.5 | 2.4.6 |
| numpy (3.10) | 2.2.6 | 2.2.6 |
| numba | 0.64.0 | 0.67.0 |
| llvmlite | 0.46.0 | 0.49.0 |

3.11 stops at 2.4.6 and 3.10 at 2.2.6 because numpy dropped those interpreters, not because of anything in our tree.

Full non-e2e suite passes on the upgraded set — 163 passed, 36 deselected, on 3.13 / numpy 2.5.2.

## Run CI weekly

Adds `schedule: "0 0 * * 0"` (Sundays 00:00 UTC) and `workflow_dispatch`.

`uv.lock` is gitignored, so uv resolves fresh on every CI run — a scheduled build tests against current upstream releases and will surface a breaking numpy or numba version before users hit it. That matters more now that the upper bound is gone.

e2e tests stay excluded; they need a GPU, which GitHub-hosted runners don't provide.

## Notes

- No CHANGELOG entry yet — to be added after merge.
- GitHub disables cron on repos with no commits for 60 days, so a silent absence of runs is worth knowing about as a failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)