### PR TITLE
Prepare 0.6.1: changelog and sdist pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.1] - Aug 13, 2026
+
+### Changed
+- The `numpy` upper bound is removed; the declared range is now `numpy>=2.0`, up from `numpy>=2.0,<2.4`. The cap was there to keep `numba` installable, but numba is not a runtime dependency — it reaches this project only through the dev group, via `s2mosaic` → `numbagg` → `numba` — so the bound constrained every install to protect a package users never receive. numba declares its own ceiling in any case (`numpy<2.6` as of 0.67), which the resolver honours without help here. A fresh resolve now reaches numpy 2.5.2 on Python 3.12+ and 2.4.6 on 3.11; 3.10 stays on 2.2.6, and 3.11 stops short of 2.5, because numpy itself dropped those interpreters.
+
+### Fixed
+- The source distribution no longer carries the example notebooks, shrinking it from 21.7 MB to 62.7 KB. `setuptools-scm` includes every git-tracked file in the sdist, which swept in three notebooks holding embedded output imagery — 36 MB uncompressed, and effectively the entire tarball. A `MANIFEST.in` now prunes `examples/` (and `.vscode/`); `tests/` is deliberately retained, since downstream packagers run the suite against the sdist. Wheels were never affected — they are built from the declared `packages` — so this changes nothing for a normal `pip install`, but it does cut what conda-forge and source builds have to fetch. The notebooks remain on GitHub, where the README links them.
+
 ## [0.6.0] - Aug 11, 2026
 
 ### Changed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+# setuptools-scm puts every git-tracked file in the sdist, which swept in the
+# example notebooks. They carry embedded output imagery — 36 MB across three
+# files — and made up essentially the whole 21 MB tarball, for content nobody
+# installing the package needs. They stay on GitHub, where the README links
+# them. The wheel was never affected; it is built from `packages` alone.
+prune examples
+
+# Editor config, of no use to anyone unpacking the sdist.
+prune .vscode
+
+# tests/ is kept deliberately: downstream packagers (conda-forge) run the suite
+# against the sdist.


### PR DESCRIPTION
Release prep for 0.6.1. No runtime code changes.

## Changelog

Adds the `## [0.6.1]` section, covering the numpy unpin from #5 and the sdist fix below.

## Keep example notebooks out of the sdist

`setuptools-scm` puts every git-tracked file into the source distribution, which swept in the three example notebooks. They carry embedded output imagery and made up essentially the entire tarball:

| Notebook | Size |
|---|---|
| `Sentinel 2 example.ipynb` | 25 MB |
| `NAIP example.ipynb` | 9 MB |
| `Sentinel 2 cloudy example.ipynb` | 3 MB |

A `MANIFEST.in` now prunes `examples/` and `.vscode/`:

| | before | after |
|---|---|---|
| sdist | 21.7 MB | **62.7 KB** |
| wheel | 30.5 KB | 30.5 KB (unchanged) |

`tests/` is retained deliberately — downstream packagers (conda-forge) run the suite against the sdist. `assets/`, `.github/`, README, LICENSE, CHANGELOG and the package data (`model_download_links.csv`, `py.typed`) all still ship.

Wheels were never affected, since they build from the declared `packages`, so a normal `pip install` is unchanged. This cuts what conda-forge and source builds fetch, and what the GitHub release attaches — v0.6.0's release carries a 20 MB `tar.gz` for the same reason.

## Verification

- Pruned sdist still builds a wheel from itself, byte-identical at 31,210 bytes, with the version resolving correctly outside a git checkout — the conda-forge path.
- ruff clean; mypy clean on 9 files; 163 tests passed, 36 deselected.

Tag `v0.6.1` to be pushed after merge, which fires `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)