### PR TITLE
Move the publish workflow's actions off Node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build sdist + wheel
         run: uv build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -49,7 +49,7 @@ jobs:
       id-token: write  # required for trusted publishing
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -64,12 +64,12 @@ jobs:
       contents: write  # required to create releases
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true


### PR DESCRIPTION
## Summary

The 0.6.2 publish run warned that three actions were being forced onto Node 24 because they still target the deprecated Node 20 runtime:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on
Node.js 24: actions/upload-artifact@v4, actions/download-artifact@v4, softprops/action-gh-release@v2
```

Each is bumped to the current major, all of which declare `using: node24`:

| action | before | after |
|---|---|---|
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `softprops/action-gh-release` | v2 | **v3** |

## Why the intervening majors are safe here

- **`download-artifact` v5** is the only genuine breaking change: the output path for single downloads **by ID**. This workflow downloads **by name**, which the migration guide lists under "No Action Needed If".
- **`upload-artifact` v7 / `download-artifact` v8** moved to ESM and added direct unzipped uploads behind opt-in parameters (`archive`, `skip-decompress`). Defaults are unchanged, and this uploads a directory, not a single file.
- **`download-artifact` v8** now errors on a digest mismatch rather than warning — the safer default for a publish pipeline.
- **`action-gh-release` v3** is a runtime move only; no input changes.

`checkout@v6`, `setup-python@v6` and `setup-uv@v8.0.0` were each checked and already run on node24, so no other changes are needed.

## Test plan

Both workflow files still parse, and job structure is unchanged (`build`, `publish-to-pypi`, `github-release`).

Note this path only executes on a tag push, so it cannot be exercised until the next release — worth watching the run on v0.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)