### PR TITLE
Cut peak memory in the fusion, debug export and vector paths

### DIFF
--- a/omniwatermask/raster_helpers.py
+++ b/omniwatermask/raster_helpers.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 import geopandas as gpd
 import numpy as np
 import rasterio as rio
+import torch
 from numpy.typing import NDArray
 from rasterio import features
 from rasterio.transform import from_bounds
@@ -40,7 +41,7 @@ def resample_input(
 
 
 def export_to_disk(
-    array: NDArray[Any],
+    array: Union[NDArray[Any], list[Optional["torch.Tensor"]]],
     export_path: Path,
     source_path: Path,
     layer_names: list[str],
@@ -48,31 +49,81 @@ def export_to_disk(
 ) -> None:
     """Export the array to disk as a GeoTIFF.
 
+    ``array`` is either a stacked numpy array - the single-band water mask - or
+    a list of debug layers, which are written one band at a time. The list form
+    exists to keep peak memory down: the debug output is 14 layers, and holding
+    them all as float32 alongside a stacked copy costs 12.6 GB on a full
+    Sentinel-2 tile, to write bands that are serialised individually anyway.
+    Each layer is promoted as it is written and released immediately after, so
+    only one float32 band is live at a time.
+
     If ``nodata_mask`` is provided (1 = valid, 0 = no data) it is written as a
     GDAL dataset mask via ``dst.write_mask`` rather than as a regular band, so
     GIS software (e.g. QGIS) treats no-data pixels as transparent. The mask is
     embedded inside the GeoTIFF (``GDAL_TIFF_INTERNAL_MASK``) rather than written
     as a separate ``.tif.msk`` sidecar, so it travels with the file.
     """
+    layers: Optional[list[Optional["torch.Tensor"]]] = (
+        array if isinstance(array, list) else None
+    )
+    if layers is not None:
+        shape = _first_layer_shape(layers)
+        count, height, width = len(layers), shape[-2], shape[-1]
+        dtype: Any = "float32"
+    else:
+        assert not isinstance(array, list)
+        count, height, width = array.shape[0], array.shape[1], array.shape[2]
+        dtype = array.dtype
+
     with rio.open(source_path) as src:
         profile = {
-            "dtype": array.dtype,
-            "count": array.shape[0],
+            "dtype": dtype,
+            "count": count,
             "compress": "lzw",
             "nodata": None,
             "driver": "GTiff",
-            "height": array.shape[1],
-            "width": array.shape[2],
+            "height": height,
+            "width": width,
             "transform": src.transform,
             "crs": src.crs,
         }
+    if layers is not None:
+        # Writing band by band only lays out and compresses well with BAND
+        # interleave and tiles; under the default PIXEL interleave LZW has to
+        # decode and re-encode every strip once per band.
+        profile.update(interleave="band", tiled=True, blockxsize=512, blockysize=512)
 
     with rio.Env(GDAL_TIFF_INTERNAL_MASK=True):
         with rio.open(export_path, "w", **profile) as dst:
-            dst.write(array)
+            if layers is not None:
+                for index in range(count):
+                    band = _layer_as_float32(layers[index], height, width)
+                    # Drop the caller's reference as well as ours, so a layer
+                    # nothing else holds is freed before the next is promoted.
+                    layers[index] = None
+                    dst.write(band, index + 1)
+                    del band
+            else:
+                dst.write(array)
             dst.descriptions = layer_names
             if nodata_mask is not None:
                 dst.write_mask((nodata_mask * 255).astype("uint8"))
+
+
+def _first_layer_shape(layers: list[Optional["torch.Tensor"]]) -> tuple[int, ...]:
+    for layer in layers:
+        if layer is not None:
+            return tuple(layer.shape)
+    raise ValueError("export_to_disk was given no non-None layers")
+
+
+def _layer_as_float32(
+    layer: Optional["torch.Tensor"], height: int, width: int
+) -> NDArray[Any]:
+    """Promote one debug layer to the float32 band the GeoTIFF stores."""
+    if layer is None:
+        return np.zeros((height, width), dtype=np.float32)
+    return layer.float().numpy(force=True).astype(np.float32, copy=False)
 
 
 def rasterize_vector(

--- a/omniwatermask/target_builders.py
+++ b/omniwatermask/target_builders.py
@@ -156,8 +156,20 @@ def combine_vector_targets(
     if all_targets.empty:
         return None
 
-    # re-project in 3857 to buffer and then to raster crs
-    all_targets = gpd.GeoDataFrame(all_targets).to_crs("EPSG:3857")
+    # Buffering needs a projected CRS so the distance is in metres, and the
+    # raster's own CRS normally is one - Sentinel-2 is UTM. Reprojecting
+    # straight to it does in one pass what used to take two, a round trip out
+    # to EPSG:3857 and back, which cost 2.1 GB of the 2.7 GB this function
+    # spent on a Perth tile's 918k features.
+    #
+    # It also buffers by the distance actually asked for. EPSG:3857's scale
+    # factor is 1/cos(latitude), so buffering 5 m there lays down ~4.2 m on the
+    # ground at Perth, and a different amount at every other latitude. Only a
+    # geographic raster CRS still needs the detour.
+    raster_crs = CRS.from_user_input(raster_src.crs)
+    buffer_crs = raster_crs if raster_crs.is_projected else CRS.from_epsg(3857)
+
+    all_targets = gpd.GeoDataFrame(all_targets).to_crs(buffer_crs)
     if all_targets is None:
         return None
     # remove points
@@ -174,7 +186,8 @@ def combine_vector_targets(
 
     all_targets["geometry"] = all_targets.geometry.make_valid()
 
-    all_targets = gpd.GeoDataFrame(all_targets).to_crs(raster_src.crs)
+    if buffer_crs != raster_crs:
+        all_targets = gpd.GeoDataFrame(all_targets).to_crs(raster_crs)
 
     return gpd.GeoDataFrame(all_targets)
 

--- a/omniwatermask/water_inf_helpers.py
+++ b/omniwatermask/water_inf_helpers.py
@@ -308,6 +308,41 @@ def make_composite_output(
     return np.stack(output_layers), layer_names
 
 
+def _fuse_any(layers: list[torch.Tensor]) -> torch.Tensor:
+    """Combine layers with a logical OR, without stacking them first.
+
+    ``torch.stack(layers).sum(0) > 0`` materialises an (N, H, W) copy and then
+    a reduction whose dtype is promoted - bool sums to int64, eight bytes a
+    pixel. On a full Sentinel-2 tile that is 1.4 GB for four boolean layers
+    against 115 MB accumulating in place, for the same answer: every layer here
+    is non-negative, so "the sum is positive" and "any layer is set" agree.
+
+    Accumulating also sidesteps a quirk of the stacked form, which promotes the
+    whole stack to float when the list mixes dtypes - the no-data mask arrives
+    as the inference dtype while the vector targets are bool.
+    """
+    layer_iter = iter(layers)
+    fused = next(layer_iter).to(torch.bool, copy=True)
+    for layer in layer_iter:
+        fused |= layer.to(torch.bool)
+    return fused
+
+
+def _fuse_weighted(layers: list[torch.Tensor]) -> torch.Tensor:
+    """Add layers together as small integers, without stacking them first.
+
+    These targets are weighted - a pixel's value counts how many sources agree -
+    so unlike _fuse_any the sum has to be kept. uint8 is ample for that: the
+    lists here hold two or three layers, and the previous int64 result was eight
+    times wider than the counts it carried.
+    """
+    layer_iter = iter(layers)
+    fused = next(layer_iter).to(torch.uint8, copy=True)
+    for layer in layer_iter:
+        fused += layer.to(torch.uint8)
+    return fused
+
+
 def _collect_target(
     thread: Thread,
     result_queue: Queue[Any],
@@ -532,9 +567,7 @@ def integrate_water_detection_methods(
         negative_target.append(vector_negative_target)
 
     if len(negative_target) > 0:
-        negative_target_tensor: Optional[torch.Tensor] = (
-            torch.stack(negative_target).sum(0) > 0
-        )
+        negative_target_tensor: Optional[torch.Tensor] = _fuse_any(negative_target)
     else:
         negative_target_tensor = None
 
@@ -542,7 +575,7 @@ def integrate_water_detection_methods(
     if use_ndwi:
         logging.info("Optimising NDWI")
         if len(ndwi_target) > 0:
-            ndwi_target_tensor = torch.stack(ndwi_target).sum(0)
+            ndwi_target_tensor = _fuse_weighted(ndwi_target)
         else:
             ndwi_target_tensor = torch.zeros_like(ndwi_conf_tensor, dtype=torch.bool)
 
@@ -571,7 +604,7 @@ def integrate_water_detection_methods(
         normalised_accuracy = None
 
     if len(model_target) > 0:
-        model_target_tensor = torch.stack(model_target).sum(0)
+        model_target_tensor = _fuse_weighted(model_target)
     else:
         model_target_tensor = torch.zeros_like(ndwi_conf_tensor, dtype=torch.bool)
 
@@ -596,7 +629,7 @@ def integrate_water_detection_methods(
         model_conf_tensor = None
         model_binary_cleaned = None
 
-    combined_water_tensor = torch.stack(combined_water).sum(0) > 0
+    combined_water_tensor = _fuse_any(combined_water)
 
     if debug_output:
         logging.info("Exporting debug layers")

--- a/omniwatermask/water_inf_helpers.py
+++ b/omniwatermask/water_inf_helpers.py
@@ -15,6 +15,11 @@ from scipy.optimize import minimize_scalar
 from .target_builders import build_targets
 
 
+# What export_to_disk accepts: a stacked array for the single-band mask, or the
+# debug layers left as tensors so they can be promoted one at a time.
+ExportPayload = Union[NDArray[Any], list[Optional[torch.Tensor]]]
+
+
 def get_masked_iou(
     source: torch.Tensor,
     target: torch.Tensor,
@@ -287,25 +292,25 @@ def get_NDWI(
 
 def make_composite_output(
     input_dict: dict[str, Optional[torch.Tensor]],
-) -> tuple[NDArray[Any], list[str]]:
-    output_layers = []
-    layer_names = []
-    # Get the shape of the first non-None layer
-    shape = None
-    for value in input_dict.values():
-        if value is not None:
-            shape = value.shape
-            break
-    if shape is None:
+) -> tuple[list[Optional[torch.Tensor]], list[str]]:
+    """Collect the debug layers, leaving them in whatever form they arrived in.
+
+    Layers are handed on as tensors rather than promoted to float32 and stacked.
+    Most of them are natively bool or uint8 - a quarter the width - and stacking
+    doubles whatever the promoted set costs, because np.stack copies. On a full
+    Sentinel-2 tile that was 6.3 GB of float32 layers plus a 6.3 GB stacked copy
+    live at once, to write bands that are then serialised one at a time anyway.
+
+    ``export_to_disk`` promotes each layer as it writes it, so only one float32
+    band exists at a time. ``None`` is passed through rather than replaced with
+    zeros here, so an absent layer costs nothing until it is written.
+    """
+    if all(value is None for value in input_dict.values()):
         raise ValueError("make_composite_output requires at least one non-None layer")
     for key, value in input_dict.items():
-        #  if value is None, use a zero tensor to avoid missing layers
         if value is None:
-            logging.info(f"Layer {key} is None, setting to zero tensor")
-            value = torch.zeros(shape, dtype=torch.float32)
-        output_layers.append(value.float().numpy(force=True).astype(np.float32))
-        layer_names.append(key)
-    return np.stack(output_layers), layer_names
+            logging.info(f"Layer {key} is None, will be written as zeros")
+    return list(input_dict.values()), list(input_dict.keys())
 
 
 def _fuse_any(layers: list[torch.Tensor]) -> torch.Tensor:
@@ -413,7 +418,7 @@ def integrate_water_detection_methods(
     mosaic_device: Union[str, torch.device] = "cpu",
     no_data_value: int = 0,
     optimise_model: bool = True,
-) -> tuple[NDArray[Any], list[str], Optional[NDArray[Any]]]:
+) -> tuple[ExportPayload, list[str], Optional[NDArray[Any]]]:
     """Combine the NDWI, model predictions and vector targets.
 
     Returns the stacked output array, the per-band layer names, and an optional
@@ -633,6 +638,7 @@ def integrate_water_detection_methods(
 
     if debug_output:
         logging.info("Exporting debug layers")
+        final_output: ExportPayload
         final_output, layer_names = make_composite_output(
             {
                 "Water predictions": combined_water_tensor,
@@ -653,8 +659,8 @@ def integrate_water_detection_methods(
         )
         nodata_mask_np = None
     else:
-        final_output = combined_water_tensor.numpy(force=True).astype(np.uint8)
-        final_output = np.expand_dims(final_output, axis=0)
+        mask_band = combined_water_tensor.numpy(force=True).astype(np.uint8)
+        final_output = np.expand_dims(mask_band, axis=0)
         layer_names = ["Water predictions"]
         # validity mask: 1 where data is valid, 0 where no data. Written as a
         # GDAL dataset mask on export so QGIS treats nodata as transparent

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -127,7 +127,10 @@ class TestIntegrateWaterDetectionMethods:
             use_model=True,
             debug_output=True,
         )
-        assert result.ndim == 3
+        # debug output is handed on as a list of layers, promoted per band at
+        # export time rather than stacked here
+        assert isinstance(result, list)
+        assert len(result) == len(layer_names)
         assert len(layer_names) > 2
         assert "Water predictions" in layer_names
         assert "NDWI binary" in layer_names

--- a/tests/test_raster_helpers.py
+++ b/tests/test_raster_helpers.py
@@ -1,4 +1,6 @@
+import pytest
 import numpy as np
+import torch
 import geopandas as gpd
 import rasterio as rio
 from shapely.geometry import box
@@ -129,3 +131,90 @@ class TestRasterizeVector:
         gdf = gpd.GeoDataFrame(geometry=[full_poly], crs=sample_rasterio_src.crs)
         result = rasterize_vector(gdf, profile)
         assert result.sum() == 100 * 100
+
+
+class TestExportToDiskStreaming:
+    """The debug path hands over a list of layers instead of a stacked array."""
+
+    def test_writes_each_layer_as_its_own_band(self, sample_geotiff, tmp_dir):
+        layers = [
+            torch.full((100, 100), 3, dtype=torch.uint8),
+            torch.ones((100, 100), dtype=torch.bool),
+        ]
+        export_path = tmp_dir / "streamed.tif"
+        export_to_disk(
+            array=layers,
+            export_path=export_path,
+            source_path=sample_geotiff,
+            layer_names=["counts", "flags"],
+        )
+        with rio.open(export_path) as src:
+            assert src.count == 2
+            assert src.dtypes == ("float32", "float32")
+            assert src.descriptions == ("counts", "flags")
+            assert np.all(src.read(1) == 3.0)
+            assert np.all(src.read(2) == 1.0)
+
+    def test_releases_each_layer_as_it_is_written(self, sample_geotiff, tmp_dir):
+        """The memory contract: a written layer must not still be referenced.
+
+        Holding all 14 debug layers as float32 plus a stacked copy is what cost
+        12.6 GB on a full Sentinel-2 tile. Streaming only helps if each source
+        is actually dropped, which callers rely on.
+        """
+        layers = [torch.ones((50, 50)), torch.zeros((50, 50))]
+        export_to_disk(
+            array=layers,
+            export_path=tmp_dir / "released.tif",
+            source_path=sample_geotiff,
+            layer_names=["a", "b"],
+        )
+        assert layers == [None, None]
+
+    def test_none_layer_is_written_as_zeros(self, sample_geotiff, tmp_dir):
+        layers = [torch.ones((100, 100)), None]
+        export_path = tmp_dir / "with_none.tif"
+        export_to_disk(
+            array=layers,
+            export_path=export_path,
+            source_path=sample_geotiff,
+            layer_names=["present", "missing"],
+        )
+        with rio.open(export_path) as src:
+            assert np.all(src.read(2) == 0.0)
+
+    def test_uses_band_interleave_and_tiles(self, sample_geotiff, tmp_dir):
+        """Band-at-a-time writes only compress well with BAND interleave."""
+        export_path = tmp_dir / "layout.tif"
+        export_to_disk(
+            array=[torch.ones((100, 100)), torch.zeros((100, 100))],
+            export_path=export_path,
+            source_path=sample_geotiff,
+            layer_names=["a", "b"],
+        )
+        with rio.open(export_path) as src:
+            assert src.profile["tiled"] is True
+            assert src.interleaving.name.lower() == "band"
+
+    def test_all_none_is_rejected(self, sample_geotiff, tmp_dir):
+        with pytest.raises(ValueError):
+            export_to_disk(
+                array=[None, None],
+                export_path=tmp_dir / "empty.tif",
+                source_path=sample_geotiff,
+                layer_names=["a", "b"],
+            )
+
+    def test_stacked_array_path_is_unchanged(self, sample_geotiff, tmp_dir):
+        """The single-band mask still goes through as a numpy array."""
+        array = np.ones((1, 100, 100), dtype=np.uint8)
+        export_path = tmp_dir / "mask.tif"
+        export_to_disk(
+            array=array,
+            export_path=export_path,
+            source_path=sample_geotiff,
+            layer_names=["Water predictions"],
+        )
+        with rio.open(export_path) as src:
+            assert src.count == 1
+            assert src.dtypes == ("uint8",)

--- a/tests/test_target_builders.py
+++ b/tests/test_target_builders.py
@@ -1,3 +1,6 @@
+from rasterio.transform import from_bounds
+import rasterio as rio
+import numpy as np
 import logging
 from queue import Queue
 from unittest.mock import patch
@@ -582,3 +585,67 @@ class TestBuildTargetsVectorCache:
         assert len(df) == 1
         assert df["source"].iloc[0] == "overture"
         assert bool(df["ocean"].iloc[0]) is True
+
+
+class TestCombineVectorTargetsBufferCrs:
+    """Lines are buffered in a projected CRS so the distance means metres."""
+
+    @staticmethod
+    def _raster(tmp_path, crs, transform, name):
+        path = tmp_path / name
+        with rio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=100,
+            width=100,
+            count=1,
+            dtype="uint8",
+            crs=crs,
+            transform=transform,
+        ) as dst:
+            dst.write(np.zeros((1, 100, 100), "uint8"))
+        return rio.open(path)
+
+    def test_projected_raster_buffers_by_a_true_five_metres(self, tmp_path):
+        """EPSG:3857 would lay down ~4.2 m here, its scale factor at -32 lat.
+
+        Buffering in the raster's own UTM avoids both that error and the
+        reprojection round trip it used to require.
+        """
+        src = self._raster(
+            tmp_path,
+            "EPSG:32750",
+            from_bounds(390000, 6460000, 391000, 6461000, 100, 100),
+            "utm.tif",
+        )
+        line = gpd.GeoDataFrame(
+            geometry=[LineString([(390200, 6460500), (390800, 6460500)])],
+            crs="EPSG:32750",
+        ).to_crs("EPSG:4326")
+
+        out = combine_vector_targets([line], src)
+        assert out.crs == src.crs
+        minx, miny, maxx, maxy = out.total_bounds
+        # a 5 m buffer either side of a horizontal line: 10 m tall
+        assert (maxy - miny) == pytest.approx(10.0, abs=0.2)
+
+    def test_geographic_raster_still_buffers_in_metres(self, tmp_path):
+        """A degrees-based raster CRS cannot buffer in metres, so it detours."""
+        src = self._raster(
+            tmp_path,
+            "EPSG:4326",
+            from_bounds(115.80, -32.00, 115.90, -31.90, 100, 100),
+            "geo.tif",
+        )
+        line = gpd.GeoDataFrame(
+            geometry=[LineString([(115.82, -31.95), (115.88, -31.95)])],
+            crs="EPSG:4326",
+        )
+
+        out = combine_vector_targets([line], src)
+        assert out.crs == src.crs
+        assert (out.geometry.type == "Polygon").all()
+        # a few metres expressed in degrees of latitude is small but non-zero
+        minx, miny, maxx, maxy = out.total_bounds
+        assert 0 < (maxy - miny) < 0.01

--- a/tests/test_water_inf_helpers.py
+++ b/tests/test_water_inf_helpers.py
@@ -154,29 +154,44 @@ class TestGetNDWI:
 
 
 class TestMakeCompositeOutput:
-    def test_stacks_layers(self):
+    def test_returns_layers_and_names_in_order(self):
         layers = {
             "layer1": torch.ones(10, 10),
             "layer2": torch.zeros(10, 10),
         }
         output, names = make_composite_output(layers)
-        assert output.shape == (2, 10, 10)
         assert names == ["layer1", "layer2"]
+        assert len(output) == 2
+        assert all(t.shape == (10, 10) for t in output)
 
-    def test_handles_none_values(self):
+    def test_passes_none_through_rather_than_materialising_zeros(self):
+        """An absent layer should cost nothing until export writes it."""
         layers = {
             "present": torch.ones(10, 10),
             "missing": None,
         }
         output, names = make_composite_output(layers)
-        assert output.shape == (2, 10, 10)
-        # The None layer should be zeros
-        assert np.all(output[1] == 0)
+        assert names == ["present", "missing"]
+        assert output[1] is None
 
-    def test_output_dtype_is_float32(self):
-        layers = {"a": torch.ones(5, 5, dtype=torch.int32)}
+    def test_leaves_layers_in_their_own_dtype(self):
+        """Promotion to float32 happens per band at export, not here.
+
+        Most debug layers are natively bool or uint8; promoting them all up
+        front is what used to cost 6.3 GB on a full tile, doubled again by the
+        stacked copy.
+        """
+        layers = {
+            "a": torch.ones(5, 5, dtype=torch.int32),
+            "b": torch.ones(5, 5).bool(),
+        }
         output, _ = make_composite_output(layers)
-        assert output.dtype == np.float32
+        assert output[0].dtype == torch.int32
+        assert output[1].dtype == torch.bool
+
+    def test_rejects_an_all_none_dict(self):
+        with pytest.raises(ValueError):
+            make_composite_output({"a": None, "b": None})
 
 
 class TestCollectTarget:


### PR DESCRIPTION
Three independent memory reductions. The first two are output-identical; **the third changes the mask** and is the one worth reviewing hardest.

Measurements are on a full Sentinel-2 tile (10980×10980) where noted, and on a 60 km Perth-metro box carrying 918,399 Overture features (256,906 roads, 661,493 buildings) for the vector path.

## `c4e8351` — fuse target layers in place

The four places combining target layers all did `torch.stack(layers).sum(0)`. That materialises an `(N, H, W)` copy of layers that are only reduced away, and the reduction promotes dtype — summing `bool` gives `int64`, eight bytes a pixel for values that never exceed three.

| | before | after |
|---|---|---|
| boolean fusion, 4 layers | 1380 MB | 115 MB |
| weighted fusion, 3 layers | 1265 MB | 115 MB |

Every layer is non-negative, so "the sum is positive" and "any layer is set" agree for the boolean sites; the weighted sites keep their counts in `uint8`.

It also removes a quirk: `negative_target` mixes dtypes — the no-data mask arrives as the inference dtype while vector targets are `bool` — and `torch.stack` was silently promoting the whole stack to float32, or bfloat16 when that was the inference dtype.

**Verified bitwise identical against main across all 14 debug bands.**

## `220e14d` — stream the debug export

`make_composite_output` promoted every layer to float32 and stacked them. Most are natively `bool` or `uint8`, a quarter the width, and `np.stack` copies — so 14 layers meant **6.3 GB of promoted layers plus a 6.3 GB stacked copy** live at once, to write bands serialised one at a time anyway.

Layers are now handed over as-is; `export_to_disk` promotes each as it writes and releases it immediately, so one float32 band exists at a time. `None` passes through rather than becoming zeros up front.

Band-at-a-time writing needs a matching layout: under the default PIXEL interleave, LZW re-encodes every strip once per band. The streamed path sets BAND interleave and tiles.

**Peak RSS 6.22 GB → 2.22 GB (−64%)** end-to-end on a 6000² scene with all 14 debug layers. The single-band mask still goes through as a stacked array, unaffected. Output verified bitwise identical.

## `7e4f542` — buffer road lines in the raster's own CRS ⚠️ changes output

`combine_vector_targets` reprojected everything to EPSG:3857, buffered lines, then reprojected back. The detour existed to get metre units — but the raster CRS normally already has them, since Sentinel-2 is UTM.

**Peak +2.67 GB → +1.26 GB.** The two reprojections were 2.1 GB of the 2.7 GB the function spent.

It also buffers by the distance actually asked for. EPSG:3857's scale factor is `1/cos(latitude)`, so `buffer(distance=5)` laid down ~**4.24 m** at Perth — and a different amount at every other latitude, so the same code gave Kununurra and Hobart different real-world road widths.

**Roads are now a true 5 m, ~18% wider, setting 1.7% more negative-target pixels** (7,470,943 → 7,598,563 on the box measured). Negative targets suppress water, so this masks slightly more — worth validating on an urban scene before merge.

A geographic raster CRS keeps the 3857 detour. `make_valid` is unchanged.

## Verification

- 187 tests pass (9 new), ruff clean, mypy clean on Python 3.13 **and** 3.10 with numpy 2.2.6
- Trial-merges cleanly with #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)