### PR TITLE
Let e2e tests resolve the live Overture release

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,15 @@ from omniwatermask import overture_source
 
 
 @pytest.fixture(autouse=True)
-def pin_overture_release(monkeypatch):
+def pin_overture_release(request, monkeypatch):
     """Keep unit tests independent of Overture's live release discovery.
 
-    Release-resolution tests override this with their own autouse fixture.
+    e2e tests fetch from the live release on purpose - pinning a fake one there
+    turns every Overture read into a 404. Release-resolution tests override this
+    with their own autouse fixture.
     """
+    if request.node.get_closest_marker("e2e"):
+        return
     monkeypatch.setattr(overture_source, "_resolved_release", "test-release")
 
 


### PR DESCRIPTION
## Problem

`pin_overture_release` in `tests/conftest.py` is `autouse=True` with no scope guard, so it pins `overture_source._resolved_release = "test-release"` for **every** test in the suite — including the e2e tests that exist specifically to fetch from the live Overture release.

Every Overture read in those tests 404s on a release that does not exist:

```
Error reading STAC index at https://stac.overturemaps.org/test-release/collections.parquet: HTTP Error 404
FileNotFoundError: overturemaps-us-west-2/release/test-release/theme=base/type=water/
```

That fails 10 tests:

- all 6 `TestOvertureLiveFetch` tests (direct Overture fetches)
- 4 `TestPipelineConfigurations` tests that pass `use_osm_water=True` — target building raises, `make_water_mask_debug` returns `[]`, and the assertion fails as `assert 0 >= 1`

CI deselects e2e by default (`addopts = "-m 'not e2e'"`), so this only surfaces when the marker is run explicitly. It has been latent since 845949d.

## Fix

Skip the pin for `e2e`-marked tests. Unit tests stay independent of release discovery — which is what the fixture was for — while e2e tests go back to exercising the real resolution path, the thing they are meant to catch upstream changes in.

## Verification

On this branch: **36/36 e2e passed** (was 10 failed / 26 passed), **178 unit passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)