### PR TITLE
Describe the resample as a VRT instead of writing it out

### DIFF
--- a/omniwatermask/raster_helpers.py
+++ b/omniwatermask/raster_helpers.py
@@ -1,49 +1,66 @@
 from pathlib import Path
 from typing import Any, Optional, Union
+from uuid import uuid4
 
 import geopandas as gpd
 import numpy as np
 import rasterio as rio
+import rasterio.shutil
 import torch
 from numpy.typing import NDArray
 from rasterio import features
+from rasterio.enums import Resampling
 from rasterio.transform import from_bounds
+from rasterio.vrt import WarpedVRT
 
 
-def resample_input(
-    input_path: Path, resample_res: Union[int, float], output_dir: Path
-) -> Path:
-    with rio.open(input_path) as src:
-        resample_path = output_dir / f"{input_path.stem}_resample_{resample_res}m.tif"
-        if resample_path.exists():
-            return resample_path
+def resample_input(input_path: Path, resample_res: Union[int, float]) -> str:
+    """Describe ``input_path`` at ``resample_res`` without materialising it.
 
+    Returns a ``/vsimem`` path to a VRT - a couple of KB of XML saying "I am a
+    raster of this size on this grid; fetch my pixels from that GeoTIFF". It
+    opens like any other raster, so every consumer downstream still just takes a
+    path, but the resampled scene only ever exists as the array whoever reads it
+    asks for.
+
+    This used to write a full resampled GeoTIFF next to the output: a complete
+    second copy of every band on disk, including the bands the caller never
+    reads, which was then decoded a second time on the way back in.
+
+    The path is only valid within this run, and only while the VRT lives - it
+    records an absolute path to its source, and nothing cleans up ``/vsimem``
+    for you. Callers own it, and must ``rasterio.shutil.delete`` it when done.
+    """
+    vrt_path = f"/vsimem/owm_resample_{uuid4().hex}.vrt"
+    # The VRT resolves its source when reopened, by which point this dataset is
+    # long closed and the working directory is no longer anyone's promise.
+    source = Path(input_path).resolve()
+
+    with rio.open(source) as src:
         scale_factor = src.res[0] / resample_res
         new_height = round(src.height * scale_factor)
         new_width = round(src.width * scale_factor)
 
         left, bottom, right, top = src.bounds
-        profile = src.profile.copy()
-        profile.update(
-            height=new_height,
-            width=new_width,
+        with WarpedVRT(
+            src,
+            crs=src.crs,
             transform=from_bounds(left, bottom, right, top, new_width, new_height),
-            alpha="unspecified",
-        )
-        data = src.read(out_shape=(src.count, new_height, new_width))
+            width=new_width,
+            height=new_height,
+            # Matches what the read-and-write version did: rasterio's default
+            # for a decimated read is nearest, so the pixels are unchanged.
+            resampling=Resampling.nearest,
+        ) as vrt:
+            rasterio.shutil.copy(vrt, vrt_path, driver="VRT")
 
-        with rio.open(resample_path, "w", **profile) as dst:
-            dst.write(data)
-            dst.descriptions = src.descriptions
-            dst.colorinterp = src.colorinterp
-
-    return resample_path
+    return vrt_path
 
 
 def export_to_disk(
     array: Union[NDArray[Any], list[Optional["torch.Tensor"]]],
     export_path: Path,
-    source_path: Path,
+    source_path: Union[str, Path],
     layer_names: list[str],
     nodata_mask: Optional[NDArray[Any]] = None,
 ) -> None:

--- a/omniwatermask/water_inf_helpers.py
+++ b/omniwatermask/water_inf_helpers.py
@@ -395,7 +395,7 @@ def _try_collect_target(
 
 def integrate_water_detection_methods(
     input_bands: NDArray[Any],
-    input_path: Path,
+    input_path: Union[str, Path],
     cache_dir: Path,
     inference_dtype: torch.dtype,
     inference_device: torch.device,

--- a/omniwatermask/water_inf_pipeline.py
+++ b/omniwatermask/water_inf_pipeline.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import rasterio as rio
+import rasterio.shutil
 import torch
 from omnicloudmask.model_utils import (
     default_device,
@@ -234,81 +235,97 @@ def make_water_mask_debug(
             output_dir_set = output_dir
 
         output_dir_set.mkdir(exist_ok=True, parents=True)
-        # Optionally resample the input image
+        # Optionally resample the input image. resample_input hands back a
+        # /vsimem VRT rather than a written raster, so scene_path opens like any
+        # other scene while the resampled pixels stay virtual. The name it would
+        # have had is rebuilt here, since there is no longer a file to take a
+        # stem from, and input_image keeps naming the real scene in the logs.
+        resample_vrt: Optional[str] = None
+        scene_path: Union[str, Path] = input_image
+        scene_stem = input_image.stem
         if resample_res is not None:
             logging.info(f"Resampling {input_image.name} to {resample_res}m")
-            input_image = resample_input(
+            resample_vrt = resample_input(
                 input_path=input_image,
                 resample_res=resample_res,
-                output_dir=output_dir_set,
             )
+            scene_path = resample_vrt
+            scene_stem = f"{input_image.stem}_resample_{resample_res}m"
 
-        debug_str = "_debug" if debug_output else ""
-        export_path = output_dir_set / (input_image.stem + f"_{version}{debug_str}.tif")
-
-        if export_path.exists() and not overwrite:
-            logging.info(f"Skipping {input_image.name} as it already exists")
-            output_paths.append(export_path)
-            p_bar.update(1)
-            p_bar.refresh()
-            continue
-
-        logging.info(f"Processing {input_image.name}")
-        with rio.open(input_image) as input_src:
-            input_bands = input_src.read(band_order)
-
-        logging.info(f"Predicting water mask for {input_image.name}")
         try:
-            water_predictions, layer_names, nodata_mask = (
-                integrate_water_detection_methods(
-                    input_bands=input_bands,
-                    input_path=input_image,
-                    debug_output=debug_output,
-                    inference_dtype=inference_dtype_torch,
-                    inference_device=inference_device_torch,
-                    inference_patch_size=inference_patch_size,
-                    inference_overlap_size=inference_overlap_size,
-                    batch_size=batch_size,
-                    use_osm_water=use_osm_water,
-                    aux_vector_sources=aux_vector_sources,
-                    aux_negative_vector_sources=aux_negative_vector_sources,
-                    mosaic_device=mosaic_device,
-                    use_ndwi=use_ndwi,
-                    use_model=use_model,
-                    use_osm_building_mask=use_osm_building,
-                    use_osm_roads_mask=use_osm_roads,
-                    vector_source=vector_source,
-                    include_ocean=include_ocean,
-                    cache_dir=cache_dir,
-                    use_cache=use_cache,
-                    optimise_model=optimise_model,
-                    no_data_value=no_data_value,
-                    models=models,
+            debug_str = "_debug" if debug_output else ""
+            export_path = output_dir_set / (scene_stem + f"_{version}{debug_str}.tif")
+
+            if export_path.exists() and not overwrite:
+                logging.info(f"Skipping {input_image.name} as it already exists")
+                output_paths.append(export_path)
+                p_bar.update(1)
+                p_bar.refresh()
+                continue
+
+            logging.info(f"Processing {input_image.name}")
+            with rio.open(scene_path) as input_src:
+                input_bands = input_src.read(band_order)
+
+            logging.info(f"Predicting water mask for {input_image.name}")
+            try:
+                water_predictions, layer_names, nodata_mask = (
+                    integrate_water_detection_methods(
+                        input_bands=input_bands,
+                        input_path=scene_path,
+                        debug_output=debug_output,
+                        inference_dtype=inference_dtype_torch,
+                        inference_device=inference_device_torch,
+                        inference_patch_size=inference_patch_size,
+                        inference_overlap_size=inference_overlap_size,
+                        batch_size=batch_size,
+                        use_osm_water=use_osm_water,
+                        aux_vector_sources=aux_vector_sources,
+                        aux_negative_vector_sources=aux_negative_vector_sources,
+                        mosaic_device=mosaic_device,
+                        use_ndwi=use_ndwi,
+                        use_model=use_model,
+                        use_osm_building_mask=use_osm_building,
+                        use_osm_roads_mask=use_osm_roads,
+                        vector_source=vector_source,
+                        include_ocean=include_ocean,
+                        cache_dir=cache_dir,
+                        use_cache=use_cache,
+                        optimise_model=optimise_model,
+                        no_data_value=no_data_value,
+                        models=models,
+                    )
                 )
-            )
-        except TargetBuildError:
-            # Export nothing rather than a mask built without its vector
-            # targets: it would look plausible, and the file on disk would make
-            # a re-run skip the scene. Leaving no file means the next run
-            # reprocesses it, so a transient outage costs a retry, not a batch.
-            logging.error(
-                f"Skipping {input_image.name}: its vector targets could not be "
-                f"built. See the traceback above. Re-run to retry this scene."
+            except TargetBuildError:
+                # Export nothing rather than a mask built without its vector
+                # targets: it would look plausible, and the file on disk would make
+                # a re-run skip the scene. Leaving no file means the next run
+                # reprocesses it, so a transient outage costs a retry, not a batch.
+                logging.error(
+                    f"Skipping {input_image.name}: its vector targets could not be "
+                    f"built. See the traceback above. Re-run to retry this scene."
+                )
+                p_bar.update(1)
+                p_bar.refresh()
+                continue
+
+            output_paths.append(export_path)
+            logging.info(f"Exporting {input_image.name} to {export_path}")
+            export_to_disk(
+                array=water_predictions,
+                export_path=export_path,
+                source_path=scene_path,
+                layer_names=layer_names,
+                nodata_mask=nodata_mask,
             )
             p_bar.update(1)
-            p_bar.refresh()
-            continue
+        finally:
+            # /vsimem is process-global and nothing reclaims it, so a batch that
+            # resamples would otherwise carry every scene's VRT to the end of
+            # the run. In a finally because the continues above skip past here.
+            if resample_vrt is not None:
+                rasterio.shutil.delete(resample_vrt)
 
-        output_paths.append(export_path)
-        logging.info(f"Exporting {input_image.name} to {export_path}")
-        export_to_disk(
-            array=water_predictions,
-            export_path=export_path,
-            source_path=input_image,
-            layer_names=layer_names,
-            nodata_mask=nodata_mask,
-        )
-        p_bar.update(1)
     p_bar.refresh()
     p_bar.close()
     if torch.cuda.is_available():

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -14,6 +14,7 @@ import geopandas as gpd
 import numpy as np
 import pytest
 import rasterio as rio
+import rasterio.shutil
 import torch
 from rasterio.windows import Window
 from shapely.geometry import box
@@ -102,7 +103,7 @@ class TestResampleAndExportRoundTrip:
     """Resample -> export -> read preserves spatial properties."""
 
     def test_resample_then_export(self, naip_crop, tmp_path):
-        resampled = resample_input(naip_crop, resample_res=2, output_dir=tmp_path)
+        resampled = resample_input(naip_crop, resample_res=2)
 
         with rio.open(resampled) as src:
             assert src.width == 128
@@ -117,6 +118,8 @@ class TestResampleAndExportRoundTrip:
             assert dst.width == 128
             assert dst.height == 128
             assert dst.descriptions == ("water_mask",)
+
+        rasterio.shutil.delete(resampled)
 
 
 class TestVectorCacheRoundTrip:
@@ -245,11 +248,16 @@ class TestIntegrateWaterDetectionReal:
             debug_output=True,
         )
 
-        assert result.ndim == 3
+        # Debug layers are handed back one tensor per name, not stacked.
+        assert isinstance(result, list)
+        assert len(result) == len(layer_names)
         assert len(layer_names) > 2
         assert "Water predictions" in layer_names
         assert "NDWI binary" in layer_names
         assert "Model confidence" in layer_names
+        present = [layer for layer in result if layer is not None]
+        assert present
+        assert all(tuple(layer.shape) == (256, 256) for layer in present)
 
 
 class TestFullPipelineReal:

--- a/tests/test_raster_helpers.py
+++ b/tests/test_raster_helpers.py
@@ -1,8 +1,11 @@
+from pathlib import Path
+
 import pytest
 import numpy as np
 import torch
 import geopandas as gpd
 import rasterio as rio
+import rasterio.shutil
 from shapely.geometry import box
 
 from omniwatermask.raster_helpers import (
@@ -13,39 +16,71 @@ from omniwatermask.raster_helpers import (
 
 
 class TestResampleInput:
-    def test_resamples_to_lower_resolution(self, sample_geotiff, tmp_dir):
+    def test_resamples_to_lower_resolution(self, sample_geotiff):
         """Resampling to a coarser resolution should produce a smaller raster."""
-        result = resample_input(sample_geotiff, resample_res=20, output_dir=tmp_dir)
-        assert result.exists()
+        result = resample_input(sample_geotiff, resample_res=20)
         with rio.open(result) as src:
             # Original is 10m/px (1000m / 100px), resample to 20m → 50px
             assert src.width == 50
             assert src.height == 50
+        rasterio.shutil.delete(result)
 
-    def test_resamples_to_higher_resolution(self, sample_geotiff, tmp_dir):
+    def test_resamples_to_higher_resolution(self, sample_geotiff):
         """Resampling to a finer resolution should produce a larger raster."""
-        result = resample_input(sample_geotiff, resample_res=5, output_dir=tmp_dir)
+        result = resample_input(sample_geotiff, resample_res=5)
         with rio.open(result) as src:
             assert src.width == 200
             assert src.height == 200
+        rasterio.shutil.delete(result)
 
-    def test_returns_cached_if_exists(self, sample_geotiff, tmp_dir):
-        """If the resampled file already exists, it should return early."""
-        result1 = resample_input(sample_geotiff, resample_res=20, output_dir=tmp_dir)
-        mtime1 = result1.stat().st_mtime
-        result2 = resample_input(sample_geotiff, resample_res=20, output_dir=tmp_dir)
-        assert result1 == result2
-        assert result2.stat().st_mtime == mtime1  # file was not rewritten
+    def test_writes_nothing_to_disk(self, sample_geotiff):
+        """The resampled scene is a /vsimem VRT, not a raster next to the input."""
+        before = set(sample_geotiff.parent.iterdir())
+        result = resample_input(sample_geotiff, resample_res=20)
+        assert result.startswith("/vsimem/")
+        assert not Path(result).exists()
+        assert set(sample_geotiff.parent.iterdir()) == before
+        rasterio.shutil.delete(result)
 
-    def test_preserves_crs(self, sample_geotiff, tmp_dir):
-        result = resample_input(sample_geotiff, resample_res=20, output_dir=tmp_dir)
+    def test_each_call_gets_its_own_path(self, sample_geotiff):
+        """Two live resamples must not collide in the shared /vsimem namespace."""
+        first = resample_input(sample_geotiff, resample_res=20)
+        second = resample_input(sample_geotiff, resample_res=20)
+        assert first != second
+        rasterio.shutil.delete(first)
+        # Deleting one must leave the other readable.
+        with rio.open(second) as src:
+            assert src.width == 50
+        rasterio.shutil.delete(second)
+
+    def test_readable_after_source_dataset_closed(self, sample_geotiff):
+        """The VRT resolves its source itself, long after resample_input returns."""
+        result = resample_input(sample_geotiff, resample_res=20)
+        with rio.open(result) as src, rio.open(sample_geotiff) as orig:
+            expected = orig.read([1, 2], out_shape=(2, 50, 50))
+            assert np.array_equal(src.read([1, 2]), expected)
+        rasterio.shutil.delete(result)
+
+    def test_preserves_crs(self, sample_geotiff):
+        result = resample_input(sample_geotiff, resample_res=20)
         with rio.open(result) as src, rio.open(sample_geotiff) as orig:
             assert src.crs == orig.crs
+        rasterio.shutil.delete(result)
 
-    def test_preserves_band_count(self, sample_geotiff, tmp_dir):
-        result = resample_input(sample_geotiff, resample_res=20, output_dir=tmp_dir)
+    def test_preserves_band_count(self, sample_geotiff):
+        result = resample_input(sample_geotiff, resample_res=20)
         with rio.open(result) as src, rio.open(sample_geotiff) as orig:
             assert src.count == orig.count
+        rasterio.shutil.delete(result)
+
+    def test_resolves_relative_source_paths(self, sample_geotiff, monkeypatch):
+        """A VRT outlives the cwd it was built in, so the source must be absolute."""
+        monkeypatch.chdir(sample_geotiff.parent)
+        result = resample_input(Path(sample_geotiff.name), resample_res=20)
+        monkeypatch.chdir(Path(__file__).parent)
+        with rio.open(result) as src:
+            assert src.read(1).shape == (50, 50)
+        rasterio.shutil.delete(result)
 
 
 class TestExportToDisk:

--- a/tests/test_water_inf_pipeline.py
+++ b/tests/test_water_inf_pipeline.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import rasterio.shutil
 import torch
 
 from omniwatermask.target_builders import TargetBuildError
@@ -422,3 +423,98 @@ class TestSkipsSceneWhenTargetsFail:
             )
 
         assert live_worker_threads() - before == set()
+
+
+class TestResampleIsVirtual:
+    """The resampled scene is a /vsimem VRT, never a raster on disk.
+
+    The pipeline used to hand the resample around as a written GeoTIFF, so the
+    scene path, the output name and the bands read all came from that file.
+    They now come from three separate places, and nothing on disk would catch
+    it if one of them drifted.
+    """
+
+    def _integrate_call(self, stub_pipeline):
+        assert stub_pipeline.call_args is not None
+        return stub_pipeline.call_args.kwargs
+
+    def test_reads_bands_at_the_resampled_size(
+        self, sample_geotiff, stub_pipeline, tmp_path
+    ):
+        make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+            resample_res=20,
+        )
+        # The 100x100 10m fixture at 20m is 50x50.
+        assert self._integrate_call(stub_pipeline)["input_bands"].shape == (4, 50, 50)
+
+    def test_passes_the_vrt_as_the_scene(self, sample_geotiff, stub_pipeline, tmp_path):
+        make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+            resample_res=20,
+        )
+        assert self._integrate_call(stub_pipeline)["input_path"].startswith("/vsimem/")
+
+    def test_output_keeps_the_resample_suffix(
+        self, sample_geotiff, stub_pipeline, tmp_path
+    ):
+        """The suffix used to come from the written file's stem."""
+        outputs = make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+            resample_res=20,
+        )
+        assert outputs[0].name.startswith(f"{sample_geotiff.stem}_resample_20m_")
+        assert outputs[0].exists()
+
+    def test_writes_no_resampled_raster(self, sample_geotiff, stub_pipeline, tmp_path):
+        make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+            resample_res=20,
+        )
+        written = {p.name for p in tmp_path.iterdir()} | {
+            p.name for p in sample_geotiff.parent.iterdir()
+        }
+        assert not [n for n in written if n.endswith("_resample_20m.tif")]
+
+    def test_releases_the_vrt(self, sample_geotiff, stub_pipeline, tmp_path):
+        """/vsimem is process-global; a batch that never freed it would grow."""
+        make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+            resample_res=20,
+        )
+        vrt_path = self._integrate_call(stub_pipeline)["input_path"]
+        assert not rasterio.shutil.exists(vrt_path)
+
+    def test_releases_the_vrt_when_the_scene_fails(
+        self, sample_geotiff, stub_pipeline, tmp_path
+    ):
+        """A scene skipped mid-run must not leak its VRT to the end of the batch."""
+        stub_pipeline.side_effect = TargetBuildError("no vectors")
+        make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+            resample_res=20,
+        )
+        vrt_path = self._integrate_call(stub_pipeline)["input_path"]
+        assert not rasterio.shutil.exists(vrt_path)
+
+    def test_no_vrt_without_resampling(self, sample_geotiff, stub_pipeline, tmp_path):
+        make_water_mask_debug(
+            scene_paths=[sample_geotiff],
+            band_order=[1, 2, 3, 4],
+            output_dir=tmp_path,
+        )
+        kwargs = self._integrate_call(stub_pipeline)
+        assert kwargs["input_path"] == sample_geotiff
+        assert kwargs["input_bands"].shape == (4, 100, 100)


### PR DESCRIPTION
Stacks on #11 — based on `perf-memory`, so retarget to `main` once that merges.

## The problem

`resample_input` read every band at the new resolution and wrote them out as a GeoTIFF next to the output, so the pipeline could reopen that path and read `band_order` back. That's a full second copy of the scene on disk — including bands the caller never asks for — plus a second decode of the ones it does.

| resample | left on disk |
|---|---|
| 4-band S2 tile → 20 m | 362 MB |
| 4-band S2 tile → 5 m | 5.8 GB |

Nothing downstream wanted a raster. Of the four consumers of that path, three — both `build_targets` threads and `export_to_disk` — read only `crs`, `bounds` and `transform`, and never touch a pixel. The file existed because a path was the only way to hand the resampled scene to all of them.

## The change

A VRT keeps the path and drops the copy. `resample_input` wraps the source in a `WarpedVRT` on the target grid and serialises that description to `/vsimem`, returning its path — 3 KB of XML saying "I am a raster of this size on this grid; fetch my pixels from that GeoTIFF".

It opens like any other raster, so `build_targets`, `water_inf_helpers` and `export_to_disk` are unchanged apart from widening `Path` to `str | Path`. The resampled scene only ever exists as the array the pipeline reads.

Alternatives considered: `MemoryFile` (same API, but holds an uncompressed duplicate of the resampled raster in RAM — ~240 MB on the 20 m case, wrong direction for this branch), and passing a lightweight georeferencing object instead of a path (no duplicate, but a new type and the same signature churn, since a `WarpedVRT` has no path either).

## Verification

Old vs new, same source, across down- and up-sampling:

```
res=   20  5490x5490   pixels identical: True   crs/transform/size/bounds: all True
res=   30  3660x3660   pixels identical: True   crs/transform/size/bounds: all True
res=    5  21960x21960 pixels identical: True   crs/transform/size/bounds: all True
res=  7.5  14640x14640 pixels identical: True   crs/transform/size/bounds: all True
```

Resample-and-read on a 4-band 5490×5490, end to end:

```
old: write GeoTIFF + reopen   0.62s   artefact 361.7 MB
new: /vsimem VRT + open       0.22s   artefact 0.0 MB
```

The grid arithmetic is carried over unchanged, and the VRT resamples with `nearest` — which is what a decimated rasterio read already did, so this is not a behaviour change. (It does make `Resampling.average` a one-word change if the downsampling aliasing is worth fixing later — deliberately not part of this.)

197 unit tests, 36 e2e, mypy strict and ruff all pass.

## Notes for review

- The pipeline's diff looks larger than it is: 141 lines, but 31 ignoring the reindent from wrapping the loop body in `try/finally`.
- The scene path, the output name and the bands read now come from three places rather than all from the written file's name. The `_resample_<res>m` suffix is rebuilt explicitly, and `input_image` keeps naming the real scene in the logs.
- `/vsimem` is process-global and nothing reclaims it, so the per-scene VRT is released in a `finally`. Tests cover release on both the success and `TargetBuildError` paths.
- The `exists()` cache is gone. It skipped a resample that is now free to redo, and never checked the cached file still matched its input.
- The skip-if-exists branch no longer writes a whole raster before discovering the output was already there.
- The VRT records an absolute path to its source, so it is strictly a within-run object — which is why it lives in `/vsimem` behind a `finally` rather than next to the outputs.
- Carries a merge of `main` for the e2e conftest fix (#12); without it the e2e suite can't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)